### PR TITLE
Fix invalid move on check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,6 +870,11 @@ impl Piece {
                             }
 
                             if king_gets_threatened {
+                                let mut index: usize = 0;
+                                if (&position_moving_to)
+                                    .exist_in_vec(&board.get_occupied_squares(), &mut index) {
+                                    break;
+                                }
                                 continue;
                             }
                         }


### PR DESCRIPTION
A piece can no longer move through other pieces to resolve a check.

Fixes #3 